### PR TITLE
feat(rating): 添加好评引导提示

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -200,7 +200,7 @@ async function processHEICImages(converter: HEICConverter): Promise<void> {
 }
 
 async function maybeShowRatingPrompt(successCount: number, failureCount: number): Promise<void> {
-  if (successCount < MIN_SUCCESSFUL_IMAGES_FOR_PROMPT || failureCount > 0) return
+  if (import.meta.env.FIREFOX || successCount < MIN_SUCCESSFUL_IMAGES_FOR_PROMPT || failureCount > 0) return
 
   try {
     const stored = await browser.storage.local.get(RATING_PROMPT_STORAGE_KEY)
@@ -247,10 +247,10 @@ function showRatingPrompt(successCount: number): void {
   reviewButton.type = "button"
   reviewButton.textContent = copy.review
   reviewButton.addEventListener("click", async () => {
+    window.open(STORE_REVIEW_URL, "_blank", "noopener")
     await browser.storage.local.set({
       [RATING_PROMPT_STORAGE_KEY]: { reviewClicked: true, lastPromptedAt: Date.now() },
     })
-    window.open(STORE_REVIEW_URL, "_blank", "noopener")
     prompt.remove()
   })
 
@@ -278,15 +278,15 @@ function showRatingPrompt(successCount: number): void {
 function getRatingPromptCopy(successCount: number): { text: string; review: string; feedback: string; close: string } {
   if (navigator.language.toLowerCase().startsWith("zh")) {
     return {
-      text: `View HEIC 插件帮你显示了 ${successCount} 张图片，如果觉得有帮助，请为我们好评，这将帮助更多需要的人。`,
-      review: "去商店好评",
+      text: `View HEIC 插件帮你显示了 ${successCount} 张图片，如果觉得有帮助，请为我们评价，这将帮助更多需要的人。`,
+      review: "去商店评价",
       feedback: "反馈问题",
       close: "关闭",
     }
   }
 
   return {
-    text: `View HEIC helped you display ${successCount} images. If it was useful, please leave us a good review so more people who need it can find it.`,
+    text: `View HEIC helped you display ${successCount} images. If it was useful, please leave us a review so more people who need it can find it.`,
     review: "Review in store",
     feedback: "Report issue",
     close: "Close",

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -200,12 +200,13 @@ async function processHEICImages(converter: HEICConverter): Promise<void> {
 }
 
 async function maybeShowRatingPrompt(successCount: number, failureCount: number): Promise<void> {
-  if (import.meta.env.FIREFOX || successCount < MIN_SUCCESSFUL_IMAGES_FOR_PROMPT || failureCount > 0) return
+  if (import.meta.env.FIREFOX || successCount === 0) return
 
   try {
     const stored = await browser.storage.local.get(RATING_PROMPT_STORAGE_KEY)
     const state: RatingPromptState = stored[RATING_PROMPT_STORAGE_KEY] ?? {}
     const now = Date.now()
+    const nextSuccessCount = (state.successCount ?? 0) + successCount
 
     if (
       state.reviewClicked ||
@@ -214,14 +215,21 @@ async function maybeShowRatingPrompt(successCount: number, failureCount: number)
       return
     }
 
-    const nextState = {
-      ...state,
-      successCount: (state.successCount ?? 0) + successCount,
-      lastPromptedAt: now,
+    if (nextSuccessCount < MIN_SUCCESSFUL_IMAGES_FOR_PROMPT) {
+      await browser.storage.local.set({
+        [RATING_PROMPT_STORAGE_KEY]: { ...state, successCount: nextSuccessCount },
+      })
+      return
     }
 
-    await browser.storage.local.set({ [RATING_PROMPT_STORAGE_KEY]: nextState })
-    showRatingPrompt(successCount)
+    await browser.storage.local.set({
+      [RATING_PROMPT_STORAGE_KEY]: {
+        ...state,
+        successCount: nextSuccessCount,
+        lastPromptedAt: now,
+      },
+    })
+    showRatingPrompt(nextSuccessCount)
   } catch (error) {
     console.warn("View HEIC rating prompt skipped:", error)
   }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -116,6 +116,38 @@ function injectStyles(): void {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       font-size: 14px;
       line-height: 1.45;
+      transform-origin: right bottom;
+      animation: view-heic-rating-prompt-enter 180ms cubic-bezier(0.16, 1, 0.3, 1);
+      will-change: opacity, transform;
+    }
+
+    .view-heic-rating-prompt--leaving {
+      pointer-events: none;
+      animation: view-heic-rating-prompt-exit 140ms cubic-bezier(0.4, 0, 1, 1) forwards;
+    }
+
+    @keyframes view-heic-rating-prompt-enter {
+      from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.96);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @keyframes view-heic-rating-prompt-exit {
+      from {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+
+      to {
+        opacity: 0;
+        transform: translateY(10px) scale(0.98);
+      }
     }
 
     .view-heic-rating-prompt__text {
@@ -166,6 +198,13 @@ function injectStyles(): void {
         bottom: 12px;
         left: 12px;
         max-width: none;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .view-heic-rating-prompt,
+      .view-heic-rating-prompt--leaving {
+        animation: none;
       }
     }
   `
@@ -259,7 +298,7 @@ function showRatingPrompt(successCount: number): void {
     await browser.storage.local.set({
       [RATING_PROMPT_STORAGE_KEY]: { reviewClicked: true, lastPromptedAt: Date.now() },
     })
-    prompt.remove()
+    dismissRatingPrompt(prompt)
   })
 
   const feedbackButton = document.createElement("button")
@@ -268,7 +307,7 @@ function showRatingPrompt(successCount: number): void {
   feedbackButton.textContent = copy.feedback
   feedbackButton.addEventListener("click", () => {
     window.open(ISSUE_URL, "_blank", "noopener")
-    prompt.remove()
+    dismissRatingPrompt(prompt)
   })
 
   const closeButton = document.createElement("button")
@@ -276,11 +315,17 @@ function showRatingPrompt(successCount: number): void {
   closeButton.type = "button"
   closeButton.setAttribute("aria-label", copy.close)
   closeButton.textContent = "×"
-  closeButton.addEventListener("click", () => prompt.remove())
+  closeButton.addEventListener("click", () => dismissRatingPrompt(prompt))
 
   actions.append(reviewButton, feedbackButton)
   prompt.append(closeButton, text, actions)
   document.body.appendChild(prompt)
+}
+
+function dismissRatingPrompt(prompt: HTMLElement): void {
+  if (prompt.classList.contains("view-heic-rating-prompt--leaving")) return
+  prompt.classList.add("view-heic-rating-prompt--leaving")
+  prompt.addEventListener("animationend", () => prompt.remove(), { once: true })
 }
 
 function getRatingPromptCopy(successCount: number): { text: string; review: string; feedback: string; close: string } {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -6,7 +6,7 @@ const STORE_REVIEW_URL =
   "https://chromewebstore.google.com/detail/view-heic/kpbcokcekojhfifjkbglcbaiffegecge/reviews"
 const ISSUE_URL = "https://github.com/vingeraycn/view-heic-browser-extension/issues/new"
 const RATING_PROMPT_STORAGE_KEY = "viewHeicRatingPrompt"
-const MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 5
+const MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 11
 const RATING_PROMPT_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000
 
 interface RatingPromptState {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,6 +2,19 @@ import { debounce } from "lodash-es"
 import { CONFIG, SELECTORS } from "../utils/constants"
 import { HEICConverter } from "../utils/heic-converter"
 
+const STORE_REVIEW_URL =
+  "https://chromewebstore.google.com/detail/view-heic/kpbcokcekojhfifjkbglcbaiffegecge/reviews"
+const ISSUE_URL = "https://github.com/vingeraycn/view-heic-browser-extension/issues/new"
+const RATING_PROMPT_STORAGE_KEY = "viewHeicRatingPrompt"
+const MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 5
+const RATING_PROMPT_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000
+
+interface RatingPromptState {
+  successCount?: number
+  lastPromptedAt?: number
+  reviewClicked?: boolean
+}
+
 export default defineContentScript({
   matches: ["<all_urls>"],
   runAt: "document_end",
@@ -87,6 +100,74 @@ function injectStyles(): void {
       opacity: 1;
       filter: grayscale(0%);
     }
+
+    .view-heic-rating-prompt {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      z-index: 2147483647;
+      max-width: 360px;
+      padding: 14px;
+      border: 1px solid rgba(15, 23, 42, 0.12);
+      border-radius: 12px;
+      background: #ffffff;
+      box-shadow: 0 18px 50px rgba(15, 23, 42, 0.18);
+      color: #0f172a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+      line-height: 1.45;
+    }
+
+    .view-heic-rating-prompt__text {
+      margin: 0 26px 12px 0;
+    }
+
+    .view-heic-rating-prompt__actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .view-heic-rating-prompt button {
+      border: 0;
+      border-radius: 8px;
+      padding: 8px 10px;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .view-heic-rating-prompt__primary {
+      background: #2563eb;
+      color: #ffffff;
+      font-weight: 700;
+    }
+
+    .view-heic-rating-prompt__secondary {
+      background: #f1f5f9;
+      color: #334155;
+    }
+
+    .view-heic-rating-prompt__close {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      background: transparent;
+      color: #64748b;
+      font-size: 18px;
+      line-height: 24px;
+    }
+
+    @media (max-width: 480px) {
+      .view-heic-rating-prompt {
+        right: 12px;
+        bottom: 12px;
+        left: 12px;
+        max-width: none;
+      }
+    }
   `
   document.head.appendChild(style)
 }
@@ -113,6 +194,102 @@ async function processHEICImages(converter: HEICConverter): Promise<void> {
 
   if (failureCount > 0) {
     console.warn("⚠️ 部分图片转换失败，可能是由于CORS限制或格式问题")
+  }
+
+  await maybeShowRatingPrompt(successCount, failureCount)
+}
+
+async function maybeShowRatingPrompt(successCount: number, failureCount: number): Promise<void> {
+  if (successCount < MIN_SUCCESSFUL_IMAGES_FOR_PROMPT || failureCount > 0) return
+
+  try {
+    const stored = await browser.storage.local.get(RATING_PROMPT_STORAGE_KEY)
+    const state: RatingPromptState = stored[RATING_PROMPT_STORAGE_KEY] ?? {}
+    const now = Date.now()
+
+    if (
+      state.reviewClicked ||
+      (state.lastPromptedAt && now - state.lastPromptedAt < RATING_PROMPT_COOLDOWN_MS)
+    ) {
+      return
+    }
+
+    const nextState = {
+      ...state,
+      successCount: (state.successCount ?? 0) + successCount,
+      lastPromptedAt: now,
+    }
+
+    await browser.storage.local.set({ [RATING_PROMPT_STORAGE_KEY]: nextState })
+    showRatingPrompt(successCount)
+  } catch (error) {
+    console.warn("View HEIC rating prompt skipped:", error)
+  }
+}
+
+function showRatingPrompt(successCount: number): void {
+  if (document.querySelector(".view-heic-rating-prompt")) return
+  const copy = getRatingPromptCopy(successCount)
+
+  const prompt = document.createElement("aside")
+  prompt.className = "view-heic-rating-prompt"
+  prompt.setAttribute("role", "status")
+
+  const text = document.createElement("p")
+  text.className = "view-heic-rating-prompt__text"
+  text.textContent = copy.text
+
+  const actions = document.createElement("div")
+  actions.className = "view-heic-rating-prompt__actions"
+
+  const reviewButton = document.createElement("button")
+  reviewButton.className = "view-heic-rating-prompt__primary"
+  reviewButton.type = "button"
+  reviewButton.textContent = copy.review
+  reviewButton.addEventListener("click", async () => {
+    await browser.storage.local.set({
+      [RATING_PROMPT_STORAGE_KEY]: { reviewClicked: true, lastPromptedAt: Date.now() },
+    })
+    window.open(STORE_REVIEW_URL, "_blank", "noopener")
+    prompt.remove()
+  })
+
+  const feedbackButton = document.createElement("button")
+  feedbackButton.className = "view-heic-rating-prompt__secondary"
+  feedbackButton.type = "button"
+  feedbackButton.textContent = copy.feedback
+  feedbackButton.addEventListener("click", () => {
+    window.open(ISSUE_URL, "_blank", "noopener")
+    prompt.remove()
+  })
+
+  const closeButton = document.createElement("button")
+  closeButton.className = "view-heic-rating-prompt__close"
+  closeButton.type = "button"
+  closeButton.setAttribute("aria-label", copy.close)
+  closeButton.textContent = "×"
+  closeButton.addEventListener("click", () => prompt.remove())
+
+  actions.append(reviewButton, feedbackButton)
+  prompt.append(closeButton, text, actions)
+  document.body.appendChild(prompt)
+}
+
+function getRatingPromptCopy(successCount: number): { text: string; review: string; feedback: string; close: string } {
+  if (navigator.language.toLowerCase().startsWith("zh")) {
+    return {
+      text: `View HEIC 插件帮你显示了 ${successCount} 张图片，如果觉得有帮助，请为我们好评，这将帮助更多需要的人。`,
+      review: "去商店好评",
+      feedback: "反馈问题",
+      close: "关闭",
+    }
+  }
+
+  return {
+    text: `View HEIC helped you display ${successCount} images. If it was useful, please leave us a good review so more people who need it can find it.`,
+    review: "Review in store",
+    feedback: "Report issue",
+    close: "Close",
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
     "compile": "tsc --noEmit",
+    "verify:rating-prompt": "node scripts/verify-rating-prompt.mjs",
     "verify:performance": "node scripts/verify-performance-defaults.mjs",
     "verify:src-change": "node scripts/verify-src-change-handling.mjs",
     "assets:market": "node scripts/generate-market-assets.mjs",

--- a/scripts/verify-rating-prompt.mjs
+++ b/scripts/verify-rating-prompt.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs"
+
+const content = readFileSync("entrypoints/content.ts", "utf8")
+const config = readFileSync("wxt.config.ts", "utf8")
+
+const checks = [
+  {
+    name: "rating prompt uses localized copy with the real converted count",
+    pass:
+      content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 5") &&
+      content.includes("View HEIC 插件帮你显示了 ${successCount} 张图片") &&
+      content.includes("View HEIC helped you display ${successCount} images") &&
+      content.includes("去商店好评") &&
+      content.includes("Review in store"),
+  },
+  {
+    name: "rating prompt only appears after successful batches",
+    pass: content.includes("failureCount > 0") && content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT"),
+  },
+  {
+    name: "rating prompt has local storage permission",
+    pass: config.includes('permissions: ["storage"]'),
+  },
+]
+
+const failed = checks.filter((check) => !check.pass)
+
+for (const check of checks) {
+  console.log(`${check.pass ? "PASS" : "FAIL"} ${check.name}`)
+}
+
+if (failed.length > 0) {
+  process.exit(1)
+}

--- a/scripts/verify-rating-prompt.mjs
+++ b/scripts/verify-rating-prompt.mjs
@@ -7,7 +7,7 @@ const checks = [
   {
     name: "rating prompt uses localized copy with the real converted count",
     pass:
-      content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 5") &&
+      content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 11") &&
       content.includes("View HEIC 插件帮你显示了 ${successCount} 张图片") &&
       content.includes("View HEIC helped you display ${successCount} images") &&
       content.includes("去商店评价") &&

--- a/scripts/verify-rating-prompt.mjs
+++ b/scripts/verify-rating-prompt.mjs
@@ -10,16 +10,25 @@ const checks = [
       content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT = 5") &&
       content.includes("View HEIC 插件帮你显示了 ${successCount} 张图片") &&
       content.includes("View HEIC helped you display ${successCount} images") &&
-      content.includes("去商店好评") &&
+      content.includes("去商店评价") &&
       content.includes("Review in store"),
   },
   {
     name: "rating prompt only appears after successful batches",
-    pass: content.includes("failureCount > 0") && content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT"),
+    pass:
+      content.includes("import.meta.env.FIREFOX") &&
+      content.includes("failureCount > 0") &&
+      content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT"),
+  },
+  {
+    name: "review tab opens before persisting review state",
+    pass:
+      content.indexOf('window.open(STORE_REVIEW_URL, "_blank", "noopener")') <
+      content.indexOf("[RATING_PROMPT_STORAGE_KEY]: { reviewClicked: true"),
   },
   {
     name: "rating prompt has local storage permission",
-    pass: config.includes('permissions: ["storage"]'),
+    pass: /permissions\s*:\s*\[[^\]]*["']storage["'][^\]]*\]/m.test(config),
   },
 ]
 

--- a/scripts/verify-rating-prompt.mjs
+++ b/scripts/verify-rating-prompt.mjs
@@ -14,10 +14,12 @@ const checks = [
       content.includes("Review in store"),
   },
   {
-    name: "rating prompt only appears after successful batches",
+    name: "rating prompt tracks successful conversions cumulatively",
     pass:
       content.includes("import.meta.env.FIREFOX") &&
-      content.includes("failureCount > 0") &&
+      content.includes("successCount === 0") &&
+      content.includes("nextSuccessCount < MIN_SUCCESSFUL_IMAGES_FOR_PROMPT") &&
+      content.includes("showRatingPrompt(nextSuccessCount)") &&
       content.includes("MIN_SUCCESSFUL_IMAGES_FOR_PROMPT"),
   },
   {

--- a/scripts/verify-rating-prompt.mjs
+++ b/scripts/verify-rating-prompt.mjs
@@ -29,6 +29,14 @@ const checks = [
       content.indexOf("[RATING_PROMPT_STORAGE_KEY]: { reviewClicked: true"),
   },
   {
+    name: "rating prompt animates in and out",
+    pass:
+      content.includes("@keyframes view-heic-rating-prompt-enter") &&
+      content.includes("@keyframes view-heic-rating-prompt-exit") &&
+      content.includes("prefers-reduced-motion") &&
+      content.includes("dismissRatingPrompt(prompt)"),
+  },
+  {
     name: "rating prompt has local storage permission",
     pass: /permissions\s*:\s*\[[^\]]*["']storage["'][^\]]*\]/m.test(config),
   },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   manifest: {
     name: "View HEIC",
     description: "View HEIC as Normal Image in Your Browser",
+    permissions: ["storage"],
   },
   runner: {
     disabled: true,


### PR DESCRIPTION
## 背景

当前扩展在正常工作时缺少引导满意用户评价的入口，导致 Chrome Web Store 评分更容易被失败场景的差评影响。

## 改动

- 在 HEIC 图片成功转换后增加轻量 toast，引导用户前往商店好评。
- 仅在单次批处理成功转换至少 5 张图片且无失败时展示，避免负面体验下触发索评。
- 使用 `browser.storage.local` 记录频控状态；用户点击“去商店好评”后不再弹出。
- 根据浏览器语言展示中文或英文文案，文案中的图片数量使用实际成功转换张数。
- 增加 `verify:rating-prompt` 校验脚本，防止文案、触发条件和 storage 权限被误删。

## 验证

- `pnpm compile`
- `pnpm verify:rating-prompt`
- `pnpm build`

备注：构建时仍有 WXT 现有 `runner` 配置弃用警告，与本次改动无关。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-conversion rating prompt that appears after successful HEIC processing.
  * The prompt accumulates successful conversion counts across sessions and supports English/Chinese localized text.
  * Includes actions to leave a Chrome Web Store review, open a GitHub issue, or dismiss the prompt.
* **Bug Fixes**
  * Reduced prompt frequency by enforcing a cooldown window and remembering when the user already clicked “review.”
  * Avoids showing the prompt when there were no successful conversions.
* **Chores**
  * Added an automated verification script to validate prompt text, gating logic, and required storage permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->