### PR TITLE
docs(playground): 补充上传测试入口

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -190,6 +190,14 @@
           <div class="text-center">
             <h2 data-i18n="demoTitle" class="text-4xl font-extrabold tracking-normal text-slate-950"></h2>
             <p data-i18n="demoLead" class="mx-auto mt-4 max-w-2xl text-lg leading-8 text-slate-600"></p>
+            <div class="mx-auto mt-6 flex max-w-2xl flex-col items-center gap-3 sm:flex-row sm:justify-center">
+              <a
+                href="./test-improved.html#upload-playground"
+                data-i18n="uploadPlaygroundCta"
+                class="inline-flex rounded-full bg-slate-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-slate-800"
+              ></a>
+              <span data-i18n="uploadPlaygroundLead" class="text-sm leading-6 text-slate-500"></span>
+            </div>
           </div>
           <div id="ext-status-banner" class="mt-8 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-center text-sm font-bold text-amber-800"></div>
           <div class="mt-6 grid gap-5 md:grid-cols-2 lg:grid-cols-4" id="demo-grid"></div>
@@ -318,6 +326,8 @@
           flowNote: 'Some websites block extension access to image files. When that happens, View HEIC leaves the page unchanged.',
           demoTitle: 'Live HEIC Demo',
           demoLead: 'The files below are real HEIC samples. After installing the extension, they are converted and displayed automatically.',
+          uploadPlaygroundCta: 'Test HEIC Upload',
+          uploadPlaygroundLead: 'Choose your own HEIC file and verify that upload inputs receive JPG.',
           detecting: 'Checking extension status...',
           detected: 'View HEIC is running. The images below are being converted automatically.',
           notDetectedPrefix: 'View HEIC is not detected. ',
@@ -422,6 +432,8 @@
           flowNote: '有些网站会阻止扩展读取图片文件。遇到这种情况时，View HEIC 会保持页面不变。',
           demoTitle: '实时 HEIC 演示',
           demoLead: '下方是真实 HEIC 测试文件。安装扩展后，它们会自动转换并正常显示。',
+          uploadPlaygroundCta: '测试 HEIC 上传',
+          uploadPlaygroundLead: '手动选择你的 HEIC 文件，验证上传输入框最终收到 JPG。',
           detecting: '正在检测扩展状态...',
           detected: 'View HEIC 扩展运行正常，下方图片正在自动转换显示。',
           notDetectedPrefix: '未检测到 View HEIC 扩展正在运行。请先 ',

--- a/docs/test-improved.html
+++ b/docs/test-improved.html
@@ -227,7 +227,7 @@
       </div>
 
       <!-- HEIC上传自动转换 Playground -->
-      <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+      <div id="upload-playground" class="bg-white rounded-lg shadow-sm p-6 mb-6">
         <div class="mb-4 flex flex-col gap-3 border-b border-blue-200 pb-4 md:flex-row md:items-start md:justify-between">
           <div>
             <h3 class="text-xl font-semibold text-gray-800">📤 HEIC 上传自动转换 Playground</h3>


### PR DESCRIPTION
## 变更
- 在首页 #demo 区域增加上传 HEIC 测试入口
- 将入口指向现有 test-improved.html#upload-playground
- 给上传 playground 补充锚点，方便直达

## 验证
- pnpm compile
- git diff --check